### PR TITLE
feat: correct date format and no null or empty

### DIFF
--- a/src/main/java/dev/pcvolkmer/mv64e/mtb/Converter.java
+++ b/src/main/java/dev/pcvolkmer/mv64e/mtb/Converter.java
@@ -1,5 +1,6 @@
 package dev.pcvolkmer.mv64e.mtb;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.*;
@@ -68,6 +69,7 @@ public class Converter {
         mapper.findAndRegisterModules();
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
         mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
+        mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         SimpleModule module = new SimpleModule();
         module.addDeserializer(Date.class, new JsonDeserializer<>() {
             @Override

--- a/src/main/java/dev/pcvolkmer/mv64e/mtb/Patient.java
+++ b/src/main/java/dev/pcvolkmer/mv64e/mtb/Patient.java
@@ -20,8 +20,8 @@ public class Patient {
     @Getter(onMethod_ = {@JsonProperty("birthDate"), @JsonFormat(pattern = "yyyy-MM-dd")})
     @Setter(onMethod_ = {@JsonProperty("birthDate"), @JsonFormat(pattern = "yyyy-MM-dd")})
     private Date birthDate;
-    @Getter(onMethod_ = {@JsonProperty("dateOfDeath")})
-    @Setter(onMethod_ = {@JsonProperty("dateOfDeath")})
+    @Getter(onMethod_ = {@JsonProperty("dateOfDeath"), @JsonFormat(pattern = "yyyy-MM-dd")})
+    @Setter(onMethod_ = {@JsonProperty("dateOfDeath"), @JsonFormat(pattern = "yyyy-MM-dd")})
     private Date dateOfDeath;
     @Getter(onMethod_ = {@JsonProperty("gender")})
     @Setter(onMethod_ = {@JsonProperty("gender")})

--- a/src/main/java/dev/pcvolkmer/mv64e/mtb/PeriodDate.java
+++ b/src/main/java/dev/pcvolkmer/mv64e/mtb/PeriodDate.java
@@ -11,8 +11,8 @@ import java.util.Date;
 @NoArgsConstructor
 @Builder
 public class PeriodDate {
-    @Getter(onMethod_ = {@JsonProperty("end")})
-    @Setter(onMethod_ = {@JsonProperty("end")})
+    @Getter(onMethod_ = {@JsonProperty("end"), @JsonFormat(pattern = "yyyy-MM-dd")})
+    @Setter(onMethod_ = {@JsonProperty("end"), @JsonFormat(pattern = "yyyy-MM-dd")})
     private Date end;
     @Getter(onMethod_ = {@JsonProperty("start"), @JsonFormat(pattern = "yyyy-MM-dd")})
     @Setter(onMethod_ = {@JsonProperty("start"), @JsonFormat(pattern = "yyyy-MM-dd")})


### PR DESCRIPTION
This skips serialising null values and uses date format yyyy-mm-dd for `Patient.dateOfDeath`/`PeriodDate.end`