### PR TITLE
fix: rename RnaFusionStrand member names to reflect meaning

### DIFF
--- a/src/main/java/dev/pcvolkmer/mv64e/mtb/RnaFusionStrand.java
+++ b/src/main/java/dev/pcvolkmer/mv64e/mtb/RnaFusionStrand.java
@@ -6,21 +6,21 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.IOException;
 
 public enum RnaFusionStrand {
-    EMPTY, RNA_FUSION_STRAND;
+    PLUS, MINUS;
 
     @JsonValue
     public String toValue() {
         switch (this) {
-            case EMPTY: return "+";
-            case RNA_FUSION_STRAND: return "-";
+            case PLUS: return "+";
+            case MINUS: return "-";
         }
         return null;
     }
 
     @JsonCreator
     public static RnaFusionStrand forValue(String value) throws IOException {
-        if (value.equals("+")) return EMPTY;
-        if (value.equals("-")) return RNA_FUSION_STRAND;
+        if (value.equals("+")) return PLUS;
+        if (value.equals("-")) return MINUS;
         throw new IOException("Cannot deserialize RnaFusionStrand");
     }
 }


### PR DESCRIPTION
This does not change serialisation/deserialisation. Only the member names in source code are changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated RNA fusion strand enumeration naming for consistency. JSON serialization format remains compatible with existing integrations.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/dnpm-dip/mv64e-mtb-dto-java/pull/31)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->